### PR TITLE
Add changed_by name to alarm panel

### DIFF
--- a/custom_components/sector/__init__.py
+++ b/custom_components/sector/__init__.py
@@ -68,6 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         entry.data[CONF_TEMP],
         entry.data[CONF_USERNAME],
         entry.data[CONF_PASSWORD],
+        entry.options.get(CONF_LOG_NAME),
         entry.options.get(UPDATE_INTERVAL, 60),
         websession=websession,
     )

--- a/custom_components/sector/alarm_control_panel.py
+++ b/custom_components/sector/alarm_control_panel.py
@@ -96,6 +96,8 @@ class SectorAlarmPanel(CoordinatorEntity, AlarmControlPanelEntity):
         if code:
             await self._hub.triggeralarm(command, code=code)
             self._attr_state = STATE_ALARM_ARMED_HOME
+            if self._hub.log_name:
+                self._attr_changed_by = self._hub.log_name
             self.async_write_ha_state()
 
     async def async_alarm_disarm(self, code=None) -> None:

--- a/custom_components/sector/alarm_control_panel.py
+++ b/custom_components/sector/alarm_control_panel.py
@@ -108,6 +108,8 @@ class SectorAlarmPanel(CoordinatorEntity, AlarmControlPanelEntity):
         if code:
             await self._hub.triggeralarm(command, code=code)
             self._attr_state = STATE_ALARM_DISARMED
+            if self._hub.log_name:
+                self._attr_changed_by = self._hub.log_name
             self.async_write_ha_state()
 
     async def async_alarm_arm_away(self, code=None) -> None:
@@ -118,6 +120,8 @@ class SectorAlarmPanel(CoordinatorEntity, AlarmControlPanelEntity):
         if code:
             await self._hub.triggeralarm(command, code=code)
             self._attr_state = STATE_ALARM_ARMED_AWAY
+            if self._hub.log_name:
+                self._attr_changed_by = self._hub.log_name
             self.async_write_ha_state()
 
     @callback

--- a/custom_components/sector/coordinator.py
+++ b/custom_components/sector/coordinator.py
@@ -22,6 +22,7 @@ class SectorAlarmHub:
         sector_temp: bool,
         userid: str,
         password: str,
+        log_name: str | None,
         timesync: int,
         websession: aiohttp.ClientSession,
     ) -> None:
@@ -50,6 +51,7 @@ class SectorAlarmHub:
         self._panel_id: str = ""
         self._update_sensors: bool = True
         self._timesync = timesync
+        self.log_name = log_name
 
     async def get_thermometers(self) -> list:
         """Get temp sensors."""


### PR DESCRIPTION
Fixes #47 
Requires to supply a name which is used for Sector logbook as the name which HA uses for controlling the alarm panel