### PR TITLE
enhancement: 202-remove-panel_id-get-from-api 

### DIFF
--- a/custom_components/sector/client.py
+++ b/custom_components/sector/client.py
@@ -65,12 +65,27 @@ class SectorAlarmAPI:
                         "Authorization": f"Bearer {self.access_token}",
                         "Accept": "application/json",
                     }
+
         except asyncio.TimeoutError as err:
             _LOGGER.error("Timeout occurred during login")
             raise AuthenticationError("Timeout during login") from err
         except aiohttp.ClientError as err:
             _LOGGER.error("Client error during login: %s", str(err))
             raise AuthenticationError("Client error during login") from err
+
+    async def get_panel_list(self):
+        """Retrieve available panels from the API."""
+        data = []
+        panellist_url = f"{self.API_URL}/api/account/GetPanelList"
+        response = await self._get(panellist_url)
+        _LOGGER.error(f"panel_payload: {response}")
+        if response:
+            data = [item["PanelId"] for item in response if "PanelId" in item]
+        else:
+            _LOGGER.error("Failed to retrieve any panels")
+            return []
+
+        return data
 
     async def retrieve_all_data(self):
         """Retrieve all relevant data from the API."""

--- a/custom_components/sector/client.py
+++ b/custom_components/sector/client.py
@@ -78,7 +78,7 @@ class SectorAlarmAPI:
         data = []
         panellist_url = f"{self.API_URL}/api/account/GetPanelList"
         response = await self._get(panellist_url)
-        _LOGGER.error(f"panel_payload: {response}")
+        _LOGGER.debug(f"panel_payload: {response}")
         if response:
             data = [item["PanelId"] for item in response if "PanelId" in item]
         else:

--- a/custom_components/sector/config_flow.py
+++ b/custom_components/sector/config_flow.py
@@ -11,6 +11,9 @@ from homeassistant.helpers.selector import (
     TextSelector,
     TextSelectorConfig,
     TextSelectorType,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode
 )
 
 from .const import CONF_PANEL_CODE, CONF_PANEL_ID, DOMAIN
@@ -23,38 +26,54 @@ class SectorAlarmConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    def __init__(self):
+        self.email = None
+        self.password = None
+        self.panel_code = None
+        self.panel_ids = []
+
     async def async_step_user(self, user_input=None):
         """Handle the initial step."""
         errors = {}
 
         if user_input is not None:
-            email = user_input[CONF_EMAIL]
-            password = user_input[CONF_PASSWORD]
-            panel_id = user_input[CONF_PANEL_ID]
-            panel_code = user_input[CONF_PANEL_CODE]
+            self.email = user_input[CONF_EMAIL]
+            self.password = user_input[CONF_PASSWORD]
+            self.panel_code = user_input[CONF_PANEL_CODE]
 
             # Import SectorAlarmAPI here to avoid blocking calls during module import
             from .client import AuthenticationError, SectorAlarmAPI
 
-            api = SectorAlarmAPI(self.hass, email, password, panel_id, panel_code)
+            api = SectorAlarmAPI(self.hass, self.email, self.password, None, self.panel_code)
             try:
                 await api.login()
-                await api.retrieve_all_data()
+                panel_list = await api.get_panel_list()
+
+                # Since panel_list is a list, we directly assign it to self.panel_ids
+                self.panel_ids = panel_list
+                _LOGGER.error(f"panel_ids: {self.panel_ids}")
+                if not self.panel_ids:
+                    errors["base"] = "no_panels_found"
+                elif len(self.panel_ids) == 1:
+                    # Only one panel_id found, directly save it
+                    return self.async_create_entry(
+                        title=f"Sector Alarm {self.panel_ids[0]}",
+                        data={
+                            CONF_EMAIL: self.email,
+                            CONF_PASSWORD: self.password,
+                            CONF_PANEL_CODE: self.panel_code,
+                            CONF_PANEL_ID: self.panel_ids[0],
+                        },
+                    )
+                else:
+                    # More than one panel_id, prompt user to select one
+                    return await self.async_step_select_panel()
+
             except AuthenticationError:
                 errors["base"] = "authentication_failed"
             except Exception as e:
                 errors["base"] = "unknown_error"
                 _LOGGER.exception("Unexpected exception during authentication: %s", e)
-            else:
-                return self.async_create_entry(
-                    title=f"Sector Alarm {panel_id}",
-                    data={
-                        CONF_EMAIL: email,
-                        CONF_PASSWORD: password,
-                        CONF_PANEL_ID: panel_id,
-                        CONF_PANEL_CODE: panel_code,
-                    },
-                )
 
         data_schema = vol.Schema(
             {
@@ -68,7 +87,6 @@ class SectorAlarmConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         type=TextSelectorType.PASSWORD, autocomplete="current-password"
                     )
                 ),
-                vol.Required(CONF_PANEL_ID): TextSelector(),
                 vol.Required(CONF_PANEL_CODE): TextSelector(),
             }
         )
@@ -80,3 +98,32 @@ class SectorAlarmConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    async def async_step_select_panel(self, user_input=None):
+        """Handle the panel selection step."""
+        if user_input is not None:
+            # User selected a panel_id; complete the setup
+            return self.async_create_entry(
+                title=f"Sector Alarm {user_input[CONF_PANEL_ID]}",
+                data={
+                    CONF_EMAIL: self.email,
+                    CONF_PASSWORD: self.password,
+                    CONF_PANEL_CODE: self.panel_code,
+                    CONF_PANEL_ID: user_input[CONF_PANEL_ID],
+                },
+            )
+
+        # Generate dropdown options based on retrieved panel IDs
+        panel_options = [{"value": pid, "label": f"Panel {pid}"} for pid in self.panel_ids]
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_PANEL_ID): SelectSelector(
+                    SelectSelectorConfig(
+                        options=panel_options,
+                        mode=SelectSelectorMode.DROPDOWN
+                    )
+                )
+            }
+        )
+
+        return self.async_show_form(step_id="select_panel", data_schema=data_schema)

--- a/custom_components/sector/coordinator.py
+++ b/custom_components/sector/coordinator.py
@@ -30,7 +30,7 @@ class SectorDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize the coordinator."""
         self.hass = hass
         self.api = SectorAlarmAPI(
-            hass=self.hass,
+            hass=hass,
             email=entry.data[CONF_EMAIL],
             password=entry.data[CONF_PASSWORD],
             panel_id=entry.data[CONF_PANEL_ID],

--- a/custom_components/sector/coordinator.py
+++ b/custom_components/sector/coordinator.py
@@ -30,7 +30,7 @@ class SectorDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize the coordinator."""
         self.hass = hass
         self.api = SectorAlarmAPI(
-            hass,
+            hass=self.hass,
             email=entry.data[CONF_EMAIL],
             password=entry.data[CONF_PASSWORD],
             panel_id=entry.data[CONF_PANEL_ID],


### PR DESCRIPTION
Add support to retreive the panel ids directly from the API rather than having to specify it manually. Although untested HA will prompt you to select the Panel which you want to connect to if you've more than 1 available through your account.
