### PR TITLE
feat: Add support for Sector Alarm event entities and log ingestion

### DIFF
--- a/custom_components/sector/__init__.py
+++ b/custom_components/sector/__init__.py
@@ -14,7 +14,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: SectorAlarmConfigEntry) 
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
 
+    # Register the listener for configuration updates
     entry.async_on_unload(entry.add_update_listener(async_update_listener))
+
+    # Store the coordinator in hass.data using entry ID for unique identification
+    hass.data.setdefault(entry.entry_id, coordinator)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/sector/camera.py
+++ b/custom_components/sector/camera.py
@@ -23,13 +23,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ):
     """Set up Sector Alarm cameras."""
-    coordinator: SectorDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    # Access coordinator directly by entry.entry_id
+    coordinator: SectorDataUpdateCoordinator = hass.data[entry.entry_id]
     devices = coordinator.data.get("devices", {})
     cameras = devices.get("cameras", [])
-    entities = []
-
-    for camera_data in cameras:
-        entities.append(SectorAlarmCamera(coordinator, camera_data))
+    entities = [SectorAlarmCamera(coordinator, camera_data) for camera_data in cameras]
 
     if entities:
         async_add_entities(entities)

--- a/custom_components/sector/client.py
+++ b/custom_components/sector/client.py
@@ -306,6 +306,17 @@ class SectorAlarmAPI:
         _LOGGER.error("Failed to retrieve image for camera %s", serial_no)
         return None
 
+    async def get_logs(self, take=100):
+        """Retrieve logs from the API."""
+        url = f"{self.API_URL}/api/panel/GetLogs?panelId={self.panel_id}&take={take}"
+        response = await self._get(url)
+        if response:
+            return response
+        _LOGGER.error("Failed to retrieve logs")
+
+        return []
+
+
     async def logout(self):
         """Logout from the API."""
         logout_url = f"{self.API_URL}/api/Login/Logout"

--- a/custom_components/sector/const.py
+++ b/custom_components/sector/const.py
@@ -10,6 +10,7 @@ PLATFORMS = [
     Platform.LOCK,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.EVENT,
 ]
 
 CATEGORY_MODEL_MAPPING = {

--- a/custom_components/sector/event.py
+++ b/custom_components/sector/event.py
@@ -1,0 +1,140 @@
+"""Event platform for Sector Alarm integration."""
+
+import logging
+import asyncio
+import pytz
+
+from collections import defaultdict
+from homeassistant.components.event import EventEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_call_later
+from datetime import datetime
+
+from .coordinator import SectorAlarmConfigEntry, SectorDataUpdateCoordinator
+from .entity import SectorAlarmBaseEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+class SectorAlarmEvent(SectorAlarmBaseEntity, EventEntity):
+    """Representation of a Sector Alarm log event."""
+
+    def __init__(self, coordinator: SectorDataUpdateCoordinator, device_serial: str, device_name: str, device_model: str):
+        """Initialize the log event entity for a specific device."""
+        super().__init__(coordinator, device_serial, {"name": device_name}, device_model)
+
+        self._attr_unique_id = f"{device_serial}_event"
+        self._attr_name = f"{device_name} Event Log"
+        self._attr_device_class = "timestamp"
+        self._events = []  # List to store recent log events for this device
+        self._initialized = False
+        _LOGGER.debug("Sector Entry: Created SectorAlarmEvent for device: %s with serial: %s", device_name, device_serial)
+
+    async def async_added_to_hass(self):
+        """Handle entity addition to Home Assistant."""
+        self._initialized = True  # Entity is now added to Home Assistant
+        _LOGGER.debug("Sector Entry: SectorAlarmEvent entity added to Home Assistant for: %s", self._attr_name)
+
+    @property
+    def state(self) -> str:
+        """Return the most recent event type as the state."""
+        return self._events[-1]["EventType"] if self._events else "No events"
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        """Return additional attributes for the most recent log event."""
+        if not self._events:
+            return {}
+
+        recent_event = self._events[-1]
+
+        # Parse the ISO 8601 timestamp to a datetime object
+        time_str = recent_event.get("Time", "unknown")
+        try:
+            # Parse the string and localize it to UTC
+            timestamp = datetime.fromisoformat(time_str).astimezone(pytz.UTC)
+            timestamp_str = timestamp.isoformat()  # Convert back to ISO 8601 format
+        except ValueError:
+            _LOGGER.warning("Invalid timestamp format: %s", time_str)
+            timestamp_str = "unknown"
+
+        return {
+            "time": timestamp_str,
+            "channel": recent_event.get("Channel", "unknown"),
+            "user": recent_event.get("User", "unknown"),
+        }
+
+    @property
+    def event_types(self) -> list[str]:
+        """Return all unique event types for this entity's logs."""
+        return list({event["EventType"] for event in self._events})
+
+    def add_event(self, log: dict):
+        """Add a new log event to this entity."""
+        self._events.append(log)
+        if self._initialized:
+            _LOGGER.debug("Sector Entry: Adding event to %s: %s", self._attr_name, log)
+            self.async_write_ha_state()  # Only update if entity is initialized
+        else:
+            _LOGGER.debug("Sector Entry: Event added to uninitialized entity %s: %s", self._attr_name, log)
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: SectorAlarmConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+):
+    """Set up Sector Alarm events for each device based on log entries."""
+    coordinator: SectorDataUpdateCoordinator = hass.data[entry.entry_id]
+
+    # Define setup_events to be triggered once the lock setup is complete
+    async def setup_events(event=None):
+        _LOGGER.debug("Sector Entry: sector_alarm_lock_setup_complete event received, starting event setup")
+        logs = coordinator.data.get("logs", [])
+        _LOGGER.debug("Sector Entry: Processing log entries: %d logs found", len(logs))
+
+        # Map device labels (LockName) to device serial numbers
+        device_map = {device_info["name"]: serial for serial, device_info in coordinator.data["devices"].items()}
+        _LOGGER.debug("Sector Entry: Device map created: %s", device_map)
+
+        # Group logs by device serial number, using the map
+        logs_by_device = defaultdict(list)
+        for log in logs:
+            lock_name = log.get("LockName")
+            _LOGGER.debug("Sector Entry: Processing log entry: %s", log)
+
+            # Skip entries with empty or missing LockName
+            if not lock_name:
+                _LOGGER.debug("Sector Entry: Skipping log entry with missing LockName: %s", log)
+                continue
+
+            device_serial = device_map.get(lock_name)
+            if device_serial:
+                logs_by_device[device_serial].append(log)
+                _LOGGER.debug("Sector Entry: Log entry associated with device %s (serial: %s)", lock_name, device_serial)
+            else:
+                _LOGGER.warning("Sector Entry: Log entry for unrecognized device: %s", lock_name)
+
+        # Create an event entity for each device with logs
+        entities = []
+        for device_serial, device_logs in logs_by_device.items():
+            device_info = coordinator.data["devices"].get(device_serial, {})
+            device_name = device_info.get("name", "Unknown Device")
+
+            _LOGGER.debug("Sector Entry: Creating event entity for device %s with logs: %d entries", device_name, len(device_logs))
+
+            # Initialize event entity for this device and add its logs
+            event_entity = SectorAlarmEvent(coordinator, device_serial, device_name, device_info.get("model", "Unknown Model"))
+            entities.append(event_entity)
+            for log in device_logs:
+                event_entity.add_event(log)
+
+        _LOGGER.debug("Sector Entry: Adding %d event entities to Home Assistant", len(entities))
+        async_add_entities(entities)
+
+    # Attempt listener for custom event
+    _LOGGER.debug("Sector Entry: Registering listener for sector_alarm_lock_setup_complete")
+    hass.bus.async_listen_once("sector_alarm_lock_setup_complete", lambda _: hass.async_create_task(setup_events()))
+
+    # Fallback in case the custom event never fires
+    _LOGGER.debug("Sector Entry: Scheduling fallback setup after 5 seconds")
+    async_call_later(hass, 5, lambda _: hass.create_task(setup_events()))

--- a/custom_components/sector/lock.py
+++ b/custom_components/sector/lock.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
             serial_no = device["serial_no"]
             description = LockEntityDescription(
                 key=serial_no,
-                name=f"Sector {device.get('name', 'Lock')} {serial_no}",
+                name=f"{device.get('name', 'Lock')}",
             )
             entities.append(
                 SectorAlarmLock(coordinator, code_format, description, serial_no)
@@ -41,6 +41,8 @@ async def async_setup_entry(
     else:
         _LOGGER.debug("No lock entities to add.")
 
+    _LOGGER.debug("Sector Lock: Firing sector_alarm_lock_setup_complete event to notify event.py")
+    hass.bus.async_fire("sector_alarm_lock_setup_complete")
 
 class SectorAlarmLock(SectorAlarmBaseEntity, LockEntity):
     """Representation of a Sector Alarm lock."""
@@ -50,7 +52,7 @@ class SectorAlarmLock(SectorAlarmBaseEntity, LockEntity):
     def __init__(
         self,
         coordinator: SectorDataUpdateCoordinator,
-        code_format: int,
+         code_format: int,
         description: LockEntityDescription,
         serial_no: str,
     ):


### PR DESCRIPTION
- Implemented SectorAlarmEvent entity to track log events per device
- Established association between logs and pre-existing lock devices
- Resolved name and model overriding issues when adding event entities
- Parsed timestamps to compatible ISO format for Home Assistant display
- Enabled log entries to be visible in the Home Assistant logbook
- Added fallback setup and debug logging for reliable event ingestion

This update introduces event tracking for Sector Alarm, enhancing log visibility and historical tracking directly in Home Assistant.