### PR TITLE
Use the same housecheck endpoints as the app

### DIFF
--- a/custom_components/sector/endpoints.py
+++ b/custom_components/sector/endpoints.py
@@ -109,17 +109,17 @@ DATA_ENDPOINTS: set[DataEndpoint] = {
     DataEndpoint(
         type=DataEndpointType.TEMPERATURES,  # Seems not be used by Sector App
         method="POST",
-        uri=f"{API_URL}/api/v2/housecheck/temperatures",
+        uri=f"{API_URL}/api/housecheck/temperatures",
     ),
     DataEndpoint(
         type=DataEndpointType.HUMIDITY,
         method="GET",
-        uri=f"{API_URL}/api/v2/housecheck/panels/{{panelId}}/humidity",
+        uri=f"{API_URL}/api/housecheck/panels/{{panelId}}/humidity",
     ),
     DataEndpoint(
         type=DataEndpointType.DOORS_AND_WINDOWS,
         method="POST",
-        uri=f"{API_URL}/api/v2/housecheck/doorsandwindows",
+        uri=f"{API_URL}/api/housecheck/doorsandwindows",
     ),
     DataEndpoint(
         type=DataEndpointType.LEAKAGE_DETECTORS,  # Seems not be used by Sector App

--- a/tests/test_coordinator_SectorActionDataUpdateCoordinator.py
+++ b/tests/test_coordinator_SectorActionDataUpdateCoordinator.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -35,8 +35,8 @@ def _create_mock_config_entity() -> MockConfigEntry:
     )
 
 
-def _create_mock_sector_panel_info(panel_info: PanelInfo | None) -> AsyncMock:
-    coordinator_mock = AsyncMock()
+def _create_mock_sector_panel_info(panel_info: PanelInfo | None) -> Mock:
+    coordinator_mock = Mock()
     coordinator_mock.data = {"panel_info": panel_info}
     return coordinator_mock
 

--- a/tests/test_coordinator_SectorSensorDataUpdateCoordinator.py
+++ b/tests/test_coordinator_SectorSensorDataUpdateCoordinator.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -117,8 +117,8 @@ def _create_mock_config_entity() -> MockConfigEntry:
     )
 
 
-def _create_mock_sector_panel_info(panel_info: PanelInfo | None) -> AsyncMock:
-    coordinator_mock = AsyncMock()
+def _create_mock_sector_panel_info(panel_info: PanelInfo | None) -> Mock:
+    coordinator_mock = Mock()
     coordinator_mock.data = {"panel_info": panel_info}
     return coordinator_mock
 


### PR DESCRIPTION
* Confusing, but it seems the app do not include the v2 in the path for HUMIDITY and DOORS_AND_WINDOWS. My guess both works, but better to be on the safe side here.